### PR TITLE
Change GitHub Actions schedule

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
     branches-ignore:
       - "releases/**"
   schedule:
-    - cron: "5 11 * * 0"
+    - cron: "0 22 * * 0"
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update the GitHub Actions schedule to run on Sunday at 22:00 UTC instead of 11:05 UTC. This change ensures that the scheduled actions align with the desired time zone (GMT +7).