### PR TITLE
Update User-Agent and Date Expire

### DIFF
--- a/payload.py
+++ b/payload.py
@@ -23,7 +23,7 @@ payload_headers = {
         "Upgrade-Insecure-Requests": "1",
         "Origin": "https://software.kmutnb.ac.th",
         "Content-Type": "application/x-www-form-urlencoded",
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.6422.112 Safari/537.36",
         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
         "Sec-Fetch-Site": "same-origin",
         "Sec-Fetch-Mode": "navigate",
@@ -52,7 +52,7 @@ adobe_headers = {
         "Upgrade-Insecure-Requests": "1",
         "Origin": "https://software.kmutnb.ac.th",
         "Content-Type": "application/x-www-form-urlencoded",
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.6422.112 Safari/537.36",
         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
         "Sec-Fetch-Site": "same-origin",
         "Sec-Fetch-Mode": "navigate",
@@ -66,7 +66,7 @@ adobe_headers = {
 
 adobe_data = {
         "userId": '',
-        "date_expire": "2024-02-19",
+        "date_expire": "2024-06-17",
         "status_number": "0",
         "Submit_get": ''
 }


### PR DESCRIPTION
Updates the User-Agent header in the HTTP requests to use the latest version of Chrome (125.0.6422.112) instead of the previous version (121.0.0.0). Additionally, it updates the date_expire value in the adobe_data object to "2024-06-17" instead of "2024-02-19". These changes ensure that the requests are made with the latest User-Agent and the correct expiration date.