### PR TITLE
chore: Update schedule in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
     type: [opened]
     branches: [main]
   schedule:
-    - cron: "0 22 * * 0"
+    - cron: "0 22 1 * *"
 
 jobs:
   build:


### PR DESCRIPTION
Update the schedule in the workflow to run at 10:00 PM UTC on the first day of every month instead of every Sunday. Due to policy changes.